### PR TITLE
added an unset CDPATH to fix DIR problem

### DIFF
--- a/plugin/loader/preload.sh
+++ b/plugin/loader/preload.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+unset CDPATH
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 to_preload() {


### PR DESCRIPTION
if CDPATH exists the cd command echo the path setting DIR with an erroneous value making the install crash :

```
ackage loader

import (
awk: fatal: cannot open file `$GOPATH/src/github.com/ipfs/go-ipfs/plugin/loader
$GOPATH/src/github.com/ipfs/go-ipfs/plugin/loader/preload_list' for reading (No such file or directory)
)
```